### PR TITLE
Solution for the event listener exercise

### DIFF
--- a/src/Acme/DemoBundle/EventListener/RequestHeadListener.php
+++ b/src/Acme/DemoBundle/EventListener/RequestHeadListener.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Acme\DemoBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequestHeadListener
+{
+    /**
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if ($request->getMethod() == 'HEAD') {
+            // return a 200 "OK" Response to stop processing
+            $response = new Response('', 200);
+            $event->setResponse($response);
+        }
+    }
+}

--- a/src/Acme/DemoBundle/Resources/config/services.xml
+++ b/src/Acme/DemoBundle/Resources/config/services.xml
@@ -16,5 +16,9 @@
         </service>
 
         <service id="acme.demo.some_service" class="Acme\DemoBundle\Services\SomeService" />
+
+        <service id="acme.demo.request_head_listener" class="Acme\DemoBundle\EventListener\RequestHeadListener">
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="-129" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
DO NOT MERGE. It's intended to show the diff only.

It shows how to
- define an event listener
- return all HEAD requests early in the kernel.request event
